### PR TITLE
Add rest of Module CRUD utilities

### DIFF
--- a/BunnySurfers.API/BunnySurfers.API.csproj
+++ b/BunnySurfers.API/BunnySurfers.API.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoMapper" Version="13.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />

--- a/BunnySurfers.API/Controllers/ModuleController.cs
+++ b/BunnySurfers.API/Controllers/ModuleController.cs
@@ -34,5 +34,17 @@ namespace BunnySurfers.API.Controllers
             await _context.SaveChangesAsync();
             return CreatedAtAction(nameof(PostModule), new { module.ModuleId }, module);
         }
+
+        [HttpDelete("{moduleId:int}")]
+        public async Task<IActionResult> DeleteModule(int moduleId)
+        {
+            var module = await _context.Modules.FindAsync(moduleId);
+            if (module is null)
+                return NotFound($"No module with ID {moduleId} was found");
+
+            _context.Modules.Remove(module);
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
     }
 }

--- a/BunnySurfers.API/Controllers/ModuleController.cs
+++ b/BunnySurfers.API/Controllers/ModuleController.cs
@@ -1,15 +1,17 @@
-﻿using BunnySurfers.API.Data;
+﻿using AutoMapper;
+using BunnySurfers.API.Data;
+using BunnySurfers.API.DTOs;
 using BunnySurfers.API.Entities;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
 namespace BunnySurfers.API.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]
-    public class ModuleController(LMSDbContext context) : ControllerBase
+    public class ModuleController(LMSDbContext context, IMapper mapper) : ControllerBase
     {
         private readonly LMSDbContext _context = context;
+        private readonly IMapper _mapper = mapper;
 
         [HttpGet("{ModuleId:int}")]
         public async Task<ActionResult<Module>> Get(int ModuleId)
@@ -22,6 +24,15 @@ namespace BunnySurfers.API.Controllers
             _context.Entry(module).Collection(m => m.Activities).Load();
 
             return Ok(module);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<Module>> PostModule(ModuleForPostDTO moduleDTO)
+        {
+            var module = _mapper.Map<Module>(moduleDTO);
+            _context.Modules.Add(module);
+            await _context.SaveChangesAsync();
+            return CreatedAtAction(nameof(PostModule), new { module.ModuleId }, module);
         }
     }
 }

--- a/BunnySurfers.API/Controllers/ModuleController.cs
+++ b/BunnySurfers.API/Controllers/ModuleController.cs
@@ -3,6 +3,7 @@ using BunnySurfers.API.Data;
 using BunnySurfers.API.DTOs;
 using BunnySurfers.API.Entities;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace BunnySurfers.API.Controllers
 {
@@ -44,6 +45,34 @@ namespace BunnySurfers.API.Controllers
 
             _context.Modules.Remove(module);
             await _context.SaveChangesAsync();
+            return NoContent();
+        }
+
+        [HttpPut("{moduleId:int}")]
+        public async Task<IActionResult> PutModule(int moduleId, ModuleForPostDTO moduleDTO)
+        {
+            var module = await _context.Modules.FindAsync(moduleId);
+            if (module is null)
+                return NotFound($"No module with ID {moduleId} was found");
+
+            // Update module from moduleDTO
+            module.Name = moduleDTO.Name;
+            module.Description = moduleDTO.Description;
+            module.StartDate = moduleDTO.StartDate;
+            module.EndDate = moduleDTO.EndDate;
+            module.CourseId = moduleDTO.CourseId;
+
+            try
+            {
+                await _context.SaveChangesAsync();
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (_context.Modules.Find(moduleId) is null)
+                    return NotFound($"The module with ID {moduleId} is missing");
+                else
+                    throw;
+            }
             return NoContent();
         }
     }

--- a/BunnySurfers.API/DTOs/ModuleForPostDTO.cs
+++ b/BunnySurfers.API/DTOs/ModuleForPostDTO.cs
@@ -1,0 +1,13 @@
+﻿namespace BunnySurfers.API.DTOs
+{
+    public class ModuleForPostDTO
+    {
+        public required string Name { get; set; }
+        public string Description { get; set; } = string.Empty;
+        public DateOnly StartDate { get; set; }
+        public DateOnly EndDate { get; set; }
+
+        // A module belongs to a single course
+        public int CourseId { get; set; }
+    }
+}

--- a/BunnySurfers.API/Profiles/ModuleProfile.cs
+++ b/BunnySurfers.API/Profiles/ModuleProfile.cs
@@ -1,0 +1,14 @@
+﻿using AutoMapper;
+using BunnySurfers.API.DTOs;
+using BunnySurfers.API.Entities;
+
+namespace BunnySurfers.API.Profiles
+{
+    public class ModuleProfile : Profile
+    {
+        public ModuleProfile()
+        {
+            CreateMap<ModuleForPostDTO, Module>();
+        }
+    }
+}

--- a/BunnySurfers.API/Program.cs
+++ b/BunnySurfers.API/Program.cs
@@ -23,6 +23,9 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddDbContext<LMSDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("LMSDatabase")));
 
+// Add automapper for DTO conversions
+builder.Services.AddAutoMapper(typeof(Program));
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.


### PR DESCRIPTION
Add the Post, Put, and Delete methods to the ModuleController.

Uses the ModuleForPostDTO to handle creating and updating modules. This means that only module properties are specified; the collections Users, Activities, and Documents are left empty/unchanged with these methods.