### PR TITLE
Add Identity User functionality

### DIFF
--- a/BunnySurfers.API/Controllers/UsersController.cs
+++ b/BunnySurfers.API/Controllers/UsersController.cs
@@ -81,6 +81,17 @@ namespace BunnySurfers.API.Controllers
             return NoContent();
         }
 
+        // Search for a user
+        [HttpGet("find")]
+        public async Task<ActionResult<UserGetDTO?>> FindUser(
+            [FromQuery(Name = "name")] string name,
+            [FromQuery(Name = "email")] string email)
+        {
+            var user = await _context.Users.FirstOrDefaultAsync(u =>
+                u.Name == name && u.Email == email);
+            return Ok(user);
+        }
+
         // Check that the given UserRole is valid
         private static bool UserRoleIsValid(UserRole role) =>
             Enum.IsDefined(role);

--- a/BunnySurfers.Blazor/Components/Account/Pages/RegisterVerified.razor
+++ b/BunnySurfers.Blazor/Components/Account/Pages/RegisterVerified.razor
@@ -1,0 +1,50 @@
+﻿@page "/Account/RegisterVerified"
+
+<PageTitle>Register</PageTitle>
+
+<h1>Register</h1>
+
+<div class="row">
+    <div class="col-md-4">
+        <StatusMessage Message="@Message" />
+        <EditForm Model="Input" asp-route-returnUrl="@ReturnUrl" method="post" OnValidSubmit="RegisterUser" FormName="register">
+            <DataAnnotationsValidator />
+            <h2>Create a new account.</h2>
+            <hr />
+            <ValidationSummary class="text-danger" role="alert" />
+            <div class="form-floating mb-3">
+                <InputText @bind-Value="Input.Name" class="form-control" autocomplete="Name" aria-required="true" placeholder="Enter name" />
+                <label for="Name">Name</label>
+                <ValidationMessage For="() => Input.Name" class="text-danger" />
+            </div>
+            <div class="form-floating mb-3">
+                <InputText @bind-Value="Input.Email" class="form-control" autocomplete="Email" aria-required="true" placeholder="Enter name" />
+                <label for="Email">Email</label>
+                <ValidationMessage For="() => Input.Email" class="text-danger" />
+            </div>
+            <div class="form-floating mb-3">
+                <InputText @bind-Value="Input.Username" class="form-control" autocomplete="Username" aria-required="true" placeholder="Enter username" />
+                <label for="Username">Username</label>
+                <ValidationMessage For="() => Input.Username" class="text-danger" />
+            </div>
+            <div class="form-floating mb-3">
+                <InputText type="password" @bind-Value="Input.Password" class="form-control" autocomplete="new-password" aria-required="true" placeholder="Choose password" />
+                <label for="password">Password</label>
+                <ValidationMessage For="() => Input.Password" class="text-danger" />
+            </div>
+            <div class="form-floating mb-3">
+                <InputText type="password" @bind-Value="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" placeholder="Repeat password" />
+                <label for="confirm-password">Confirm Password</label>
+                <ValidationMessage For="() => Input.ConfirmPassword" class="text-danger" />
+            </div>
+            <button type="submit" class="w-100 btn btn-lg btn-primary">Register</button>
+        </EditForm>
+    </div>
+    <div class="col-md-6 col-md-offset-2">
+        <section>
+            <h3>Use another service to register.</h3>
+            <hr />
+            <ExternalLoginPicker />
+        </section>
+    </div>
+</div>

--- a/BunnySurfers.Blazor/Components/Account/Pages/RegisterVerified.razor.cs
+++ b/BunnySurfers.Blazor/Components/Account/Pages/RegisterVerified.razor.cs
@@ -1,0 +1,150 @@
+﻿using BunnySurfers.API.DTOs;
+using BunnySurfers.Blazor.Data;
+using BunnySurfers.Blazor.Services;
+using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.WebUtilities;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Encodings.Web;
+using System.Text;
+
+namespace BunnySurfers.Blazor.Components.Account.Pages
+{
+    public partial class RegisterVerified
+    {
+        [Inject]
+        private UserManager<ApplicationUser> UserManager { get; set; } = null!;
+        [Inject]
+        private IUserStore<ApplicationUser> UserStore { get; set; } = null!;
+        [Inject]
+        private SignInManager<ApplicationUser> SignInManager { get; set; } = null!;
+        [Inject]
+        private IEmailSender<ApplicationUser> EmailSender { get; set; } = null!;
+        [Inject]
+        private ILogger<Register> Logger { get; set; } = null!;
+        [Inject]
+        private NavigationManager NavigationManager { get; set; } = null!;
+        [Inject]
+        private IdentityRedirectManager RedirectManager { get; set; } = null!;
+        [Inject]
+        private IUserService UserService { get; set; } = null!;
+
+        private readonly List<IdentityError> identityErrors = [];
+
+        [SupplyParameterFromForm]
+        private InputModel Input { get; set; } = new();
+
+        [SupplyParameterFromQuery]
+        private string? ReturnUrl { get; set; }
+
+        private string? Message => identityErrors.Count == 0 ? null : $"Error: {string.Join(", ", identityErrors.Select(error => error.Description))}";
+
+        public async Task RegisterUser(EditContext editContext)
+        {
+            var succeeded = await Input.RetrieveUser(UserService, identityErrors);
+            if (!succeeded)
+                return;
+
+            var user = CreateUser();
+
+            await UserStore.SetUserNameAsync(user, Input.Username, CancellationToken.None);
+            var emailStore = GetEmailStore();
+            await emailStore.SetEmailAsync(user, Input.Username, CancellationToken.None);
+            var result = await UserManager.CreateAsync(user, Input.Password);
+
+            if (!result.Succeeded)
+            {
+                identityErrors.AddRange(result.Errors);
+                return;
+            }
+
+            Logger.LogInformation("User created a new account with password.");
+
+            var userId = await UserManager.GetUserIdAsync(user);
+            var code = await UserManager.GenerateEmailConfirmationTokenAsync(user);
+            code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
+            var callbackUrl = NavigationManager.GetUriWithQueryParameters(
+                NavigationManager.ToAbsoluteUri("Account/ConfirmEmail").AbsoluteUri,
+                new Dictionary<string, object?> { ["userId"] = userId, ["code"] = code, ["returnUrl"] = ReturnUrl });
+
+            await EmailSender.SendConfirmationLinkAsync(user, Input.Username, HtmlEncoder.Default.Encode(callbackUrl));
+
+            if (UserManager.Options.SignIn.RequireConfirmedAccount)
+            {
+                RedirectManager.RedirectTo(
+                    "Account/RegisterConfirmation",
+                    new() { ["email"] = Input.Username, ["returnUrl"] = ReturnUrl });
+            }
+
+            await SignInManager.SignInAsync(user, isPersistent: false);
+            RedirectManager.RedirectTo(ReturnUrl);
+        }
+
+        private ApplicationUser CreateUser()
+        {
+            try
+            {
+                return Activator.CreateInstance<ApplicationUser>();
+            }
+            catch
+            {
+                throw new InvalidOperationException($"Can't create an instance of '{nameof(ApplicationUser)}'. " +
+                    $"Ensure that '{nameof(ApplicationUser)}' is not an abstract class and has a parameterless constructor.");
+            }
+        }
+
+        private IUserEmailStore<ApplicationUser> GetEmailStore()
+        {
+            if (!UserManager.SupportsUserEmail)
+            {
+                throw new NotSupportedException("The default UI requires a user store with email support.");
+            }
+            return (IUserEmailStore<ApplicationUser>)UserStore;
+        }
+
+        private sealed class InputModel
+        {
+            [Required]
+            [Display(Name = "Name")]
+            public string Name { get; set; } = "";
+
+            [Required]
+            [Display(Name = "Email")]
+            [EmailAddress]
+            public string Email { get; set; } = "";
+
+            [Required]
+            [Display(Name = "Username")]
+            public string Username { get; set; } = "";
+
+            [Required]
+            [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
+            [DataType(DataType.Password)]
+            [Display(Name = "Password")]
+            public string Password { get; set; } = "";
+
+            [DataType(DataType.Password)]
+            [Display(Name = "Confirm password")]
+            [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
+            public string ConfirmPassword { get; set; } = "";
+
+            public UserGetDTO? UserDTO { get; set; } = null!;
+
+            public async Task<bool> RetrieveUser(IUserService userService, List<IdentityError> identityErrors)
+            {
+                UserDTO = await userService.FindUser(Name, Email);
+                if (UserDTO is null)
+                {
+                    identityErrors.Add(new()
+                    {
+                        Code = nameof(RetrieveUser),
+                        Description = $"Could not find the user with Name='{Name}', Email='{Email}' in the API database."
+                    });
+                    return false;
+                }
+                return true;
+            }
+        }
+    }
+}

--- a/BunnySurfers.Blazor/Components/Pages/UserAdd.razor.cs
+++ b/BunnySurfers.Blazor/Components/Pages/UserAdd.razor.cs
@@ -9,6 +9,8 @@ namespace BunnySurfers.Blazor.Components.Pages
     {
         [Inject]
         public IUserService UserService { get; set; } = null!;
+        [Inject]
+        public IApplicationUserService ApplicationUserService { get; set; } = null!;
 
         [SupplyParameterFromForm]
         public UserEditDTO UserDTO { get; set; } = null!;
@@ -25,17 +27,17 @@ namespace BunnySurfers.Blazor.Components.Pages
         public async Task HandleValidSubmit()
         {
             var success = await UserService.CreateUser(UserDTO);
-            if (success)
-            {
-                StatusClass = "alert-success";
-                StatusMessage = "Employee updated successfully";
-                IsSaved = true;
-            }
-            else
+            if (!success)
             {
                 StatusClass = "alert-danger";
-                StatusMessage = "There was an error adding the employee to the database";
+                StatusMessage = "There was an error adding the user to the database";
+                return;
             }
+
+            await ApplicationUserService.AddUser(UserDTO);
+            StatusClass = "alert-success";
+            StatusMessage = "User added successfully";
+            IsSaved = true;
         }
 
         public void HandleInvalidSubmit()

--- a/BunnySurfers.Blazor/Components/Pages/UserEdit.razor
+++ b/BunnySurfers.Blazor/Components/Pages/UserEdit.razor
@@ -10,7 +10,7 @@
 else if (UserDTO is null)
 {
     <p>No user with ID @UserId could be found.</p>
-    <NavLink href="/usermanagement">Back to user list</NavLink>
+    <NavLink href="/users">Back to user list</NavLink>
 }
 else
 {
@@ -36,5 +36,5 @@ else
         </div>
     </EditForm>
 
-    <NavLink href="/usermanagement">Back to user list</NavLink>
+    <NavLink href="/users">Back to user list</NavLink>
 }

--- a/BunnySurfers.Blazor/Components/Pages/Users.razor
+++ b/BunnySurfers.Blazor/Components/Pages/Users.razor
@@ -14,7 +14,7 @@ else if (getUsersError || UserList is null)
 else if (UserList.Count() == 0)
 {
     <p>There are currently no users in the database.</p>
-    <NavLink href="/usermanagement/add">Add new user</NavLink>
+    <NavLink href="/users/add">Add new user</NavLink>
 }
 else
 {
@@ -23,7 +23,7 @@ else
         <div class="@StatusClass">@StatusMessage</div>
     }
 
-    <NavLink href="/usermanagement/add">Add new user</NavLink>
+    <NavLink href="/users/add">Add new user</NavLink>
 
     <table>
         <thead>
@@ -42,7 +42,7 @@ else
                     <td>@user.Email</td>
                     <td>@user.Role</td>
                     <td>
-                        <NavLink href=@($"/usermanagement/{user.UserId}")>Edit</NavLink>
+                        <NavLink href=@($"/users/edit/{user.UserId}")>Edit</NavLink>
                         <button type="button" @onclick="@(_ => DeleteUser(user.UserId))">Delete</button>
                     </td>
                 </tr>

--- a/BunnySurfers.Blazor/Data/SeedUserData.cs
+++ b/BunnySurfers.Blazor/Data/SeedUserData.cs
@@ -1,0 +1,57 @@
+﻿using BunnySurfers.API.Entities;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.AspNetCore.Identity;
+
+namespace BunnySurfers.Blazor.Data
+{
+    public class SeedUserData(ApplicationDbContext context)
+    {
+        private readonly ApplicationDbContext _context = context;
+
+        public void ClearUserDatabase()
+        {
+            _context.Database.EnsureDeleted();
+            _context.Database.EnsureCreated();
+        }
+
+        public async Task SeedUserRoles()
+        {
+            foreach (var role in Enum.GetValues<UserRole>().Cast<UserRole>())
+            {
+                var roleStore = new RoleStore<IdentityRole>(_context);
+                if (!_context.Roles.Any(r => r.Name == role.ToString()))
+                    await roleStore.CreateAsync(new IdentityRole
+                    {
+                        Name = role.ToString(),
+                        NormalizedName = role.ToString().ToUpperInvariant()
+                    });
+            }
+            await _context.SaveChangesAsync();
+        }
+        
+        public async Task SeedUserDatabase()
+        {
+            var user = new ApplicationUser
+            {
+                Email = "admin@admin.com",
+                NormalizedEmail = "ADMIN@ADMIN.COM",
+                UserName = "Admin",
+                NormalizedUserName = "ADMIN",
+                EmailConfirmed = true,
+            };
+
+            if (!_context.Users.Any(u => u.UserName == user.UserName))
+            {
+                var password = new PasswordHasher<ApplicationUser>();
+                var hashed = password.HashPassword(user, "asd,./123");
+                user.PasswordHash = hashed;
+
+                var userStore = new UserStore<ApplicationUser>(_context);
+                await userStore.CreateAsync(user);
+                await userStore.AddToRoleAsync(user, UserRole.Admin.ToString().ToUpperInvariant());
+            }
+
+            await _context.SaveChangesAsync();
+        }
+    }
+}

--- a/BunnySurfers.Blazor/Program.cs
+++ b/BunnySurfers.Blazor/Program.cs
@@ -26,6 +26,7 @@ builder.Services.AddScoped<AuthenticationStateProvider, IdentityRevalidatingAuth
 builder.Services.AddScoped<ICourseService, CourseService>();
 builder.Services.AddScoped<IModuleService, ModuleService>();
 builder.Services.AddScoped<IUserService, UserService>();
+builder.Services.AddScoped<IApplicationUserService, ApplicationUserService>();
 
 
 

--- a/BunnySurfers.Blazor/Program.cs
+++ b/BunnySurfers.Blazor/Program.cs
@@ -61,12 +61,16 @@ builder.Services.AddIdentityCore<ApplicationUser>(options => options.SignIn.Requ
 
 builder.Services.AddSingleton<IEmailSender<ApplicationUser>, IdentityNoOpEmailSender>();
 
+builder.Services.AddTransient<SeedUserData>();
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
     app.UseMigrationsEndPoint();
+    using var scope = app.Services.CreateScope();
+    await scope.ServiceProvider.GetRequiredService<SeedUserData>().SeedUserDatabase();
 }
 else
 {

--- a/BunnySurfers.Blazor/Services/ApplicationUserService.cs
+++ b/BunnySurfers.Blazor/Services/ApplicationUserService.cs
@@ -1,0 +1,28 @@
+﻿using BunnySurfers.API.DTOs;
+using BunnySurfers.Blazor.Data;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+
+namespace BunnySurfers.Blazor.Services
+{
+    public class ApplicationUserService(ApplicationDbContext context) : IApplicationUserService
+    {
+        private readonly ApplicationDbContext _context = context;
+
+        public async Task AddUser(UserEditDTO userDTO)
+        {
+            ApplicationUser appUser = new()
+            {
+                Email = userDTO.Email,
+                NormalizedEmail = userDTO.Email.ToUpperInvariant(),
+                EmailConfirmed = false
+            };
+
+            if (!_context.Users.Any(u => u.UserName == appUser.UserName))
+            {
+                var userStore = new UserStore<ApplicationUser>(_context);
+                await userStore.CreateAsync(appUser);
+                await userStore.AddToRoleAsync(appUser, userDTO.Role.ToString().ToUpperInvariant());
+            }
+        }
+    }
+}

--- a/BunnySurfers.Blazor/Services/IApplicationUserService.cs
+++ b/BunnySurfers.Blazor/Services/IApplicationUserService.cs
@@ -1,0 +1,9 @@
+﻿using BunnySurfers.API.DTOs;
+
+namespace BunnySurfers.Blazor.Services
+{
+    public interface IApplicationUserService
+    {
+        Task AddUser(UserEditDTO userDTO);
+    }
+}

--- a/BunnySurfers.Blazor/Services/IUserService.cs
+++ b/BunnySurfers.Blazor/Services/IUserService.cs
@@ -9,5 +9,6 @@ namespace BunnySurfers.Blazor.Services
         Task<bool> CreateUser(UserEditDTO userDTO);
         Task<bool> UpdateUser(int userId, UserEditDTO userDTO);
         Task<bool> DeleteUser(int userId);
+        Task<UserGetDTO?> FindUser(string name, string email);
     }
 }

--- a/BunnySurfers.Blazor/Services/UserService.cs
+++ b/BunnySurfers.Blazor/Services/UserService.cs
@@ -1,4 +1,5 @@
 ﻿using BunnySurfers.API.DTOs;
+using Microsoft.AspNetCore.WebUtilities;
 
 namespace BunnySurfers.Blazor.Services
 {
@@ -28,6 +29,18 @@ namespace BunnySurfers.Blazor.Services
         {
             var response = await ApiClient.DeleteAsync($"api/users/{userId}");
             return response.IsSuccessStatusCode;
+        }
+
+        public async Task<UserGetDTO?> FindUser(string name, string email)
+        {
+            string url = "api/users/find";
+            Dictionary<string, string?> queryParams = new()
+            {
+                { "name", name },
+                { "email", email }
+            };
+            var newUrl = QueryHelpers.AddQueryString(url, queryParams);
+            return await ApiClient.GetFromJsonAsync<UserGetDTO?>(newUrl);
         }
     }
 }


### PR DESCRIPTION
- Add a simple seeded user to the Identity database.
- Users added through /users/add (e.g. by a teacher) will now also be added to the Identity database.
- A user added to the database can go to /Accounts/RegisterVerified. If they enter the correct Name and Email, they can set their username and password; register their account; and log in.